### PR TITLE
Fixed Image not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # First stage of multi-stage build
-FROM microsoft/aspnetcore-build AS build-env
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build-env
 WORKDIR /app
 
 # copy the contents of agent working directory on host to workdir in container
@@ -11,7 +11,7 @@ RUN dotnet build -c Release
 RUN dotnet publish -c Release -o out
 
 # Second stage - Build runtime image
-FROM microsoft/aspnetcore
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "pipelines-dotnet-core-docker.dll"]


### PR DESCRIPTION
Previous image reference is broken. Fixed with a compatiable image source refernce. Error message from docker build is as follows (removed all other lines)

`=> ERROR [internal] load metadata for docker.io/microsoft/aspnetcore:latest

failed to solve with frontend dockerfile.v0: failed to create LLB definition: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed`