### PR TITLE
Update Dockerfile to use working images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # First stage of multi-stage build
-FROM microsoft/aspnetcore-build AS build-env
+FROM mcr.microsoft.com/dotnet/framework/sdk AS build-env
 WORKDIR /app
 
 # copy the contents of agent working directory on host to workdir in container
@@ -11,7 +11,7 @@ RUN dotnet build -c Release
 RUN dotnet publish -c Release -o out
 
 # Second stage - Build runtime image
-FROM microsoft/aspnetcore
+FROM mcr.microsoft.com/dotnet/aspnet
 WORKDIR /app
 COPY --from=build-env /app/out .
 ENTRYPOINT ["dotnet", "pipelines-dotnet-core-docker.dll"]


### PR DESCRIPTION
The Dockerfile images are no longer working. These images work with a `windows-latest` agent. 
Fixes https://github.com/MicrosoftDocs/azure-devops-docs/issues/11476. 